### PR TITLE
Made a copy of the simulation output to convert from adjoint to matrix

### DIFF
--- a/TradeOff/src/simulate/sim.jl
+++ b/TradeOff/src/simulate/sim.jl
@@ -40,12 +40,12 @@ end
 
 # function to find the rate of substrate consumption by a particular reaction
 function qs(S::Float64,
-            P::Float64,
-            E::Float64,
-            i::Int64,
-            ps::Microbe,
-            T::Float64,
-            r::Reaction)
+        P::Float64,
+        E::Float64,
+        i::Int64,
+        ps::Microbe,
+        T::Float64,
+        r::Reaction)
     # To speed things I don't have a check here to ensure that r.ID matches ps.Reac[i]
     # This is something to check if I start getting errors
     θs = θ(S, P, T, ps.η[i], r.ΔG0)
@@ -82,11 +82,11 @@ end
 
 # function to implement the consumer resource dynamics
 function full_dynamics!(dx::Array{Float64, 1},
-                        x::Array{Float64, 1},
-                        ms::Array{Microbe, 1},
-                        ps::TOParameters,
-                        rate::Array{Float64, 2},
-                        t::Float64)
+        x::Array{Float64, 1},
+        ms::Array{Microbe, 1},
+        ps::TOParameters,
+        rate::Array{Float64, 2},
+        t::Float64)
     # loop over the reactions to find reaction rate for each reaction for each strain
     for j in 1:(ps.O)
         # Find substrate and product for this reaction
@@ -99,12 +99,12 @@ function full_dynamics!(dx::Array{Float64, 1},
                 E = Eα(x[2 * length(ms) + ps.M + i], ms[i], k)
                 # Then finally calculate reaction rate
                 rate[i, j] = qs(x[length(ms) + ps.reacs[j].Rct],
-                                x[length(ms) + ps.reacs[j].Prd],
-                                E,
-                                k,
-                                ms[i],
-                                ps.T,
-                                ps.reacs[ms[i].Reacs[k]])
+                    x[length(ms) + ps.reacs[j].Prd],
+                    E,
+                    k,
+                    ms[i],
+                    ps.T,
+                    ps.reacs[ms[i].Reacs[k]])
             else
                 rate[i, j] = 0.0
             end
@@ -183,15 +183,15 @@ end
 # are the initial conditions, mpl is a pool of microbes, mT is mean immigration time,
 # ims is the number of immigrations, λIm controls rate of additional immigrants
 function full_simulate(ps::TOParameters,
-                       pop::Float64,
-                       conc::Float64,
-                       as::Float64,
-                       ϕs::Float64,
-                       mpl::Array{Microbe, 1},
-                       Ni::Int64,
-                       mT::Float64,
-                       ims::Int64,
-                       λIm::Float64)
+        pop::Float64,
+        conc::Float64,
+        as::Float64,
+        ϕs::Float64,
+        mpl::Array{Microbe, 1},
+        Ni::Int64,
+        mT::Float64,
+        ims::Int64,
+        λIm::Float64)
     # Preallocate immigration times
     its = zeros(ims)
     # Make container to store microbial data
@@ -257,7 +257,7 @@ function full_simulate(ps::TOParameters,
     sol = DifferentialEquations.solve(prob)
     # Make containers to store dynamics
     T = sol.t
-    C = sol'
+    C = copy(sol')
     # Save this C for output
     traj[1] = C[:, :]
     # Find indices of surviving strains
@@ -361,7 +361,7 @@ function full_simulate(ps::TOParameters,
         Ns += nI
         # Store new dynamics in a temporary form
         Tt = sol.t
-        C = sol'
+        C = copy(sol')
         # Save new dynamics for output
         traj[i + 1] = C
         # Add to full vector of times
@@ -408,12 +408,12 @@ end
 
 # function to test for single population growth
 function sing_pop(ps::TOParameters,
-                  pop::Float64,
-                  conc::Float64,
-                  as::Float64,
-                  ϕs::Float64,
-                  mic::Microbe,
-                  Tmax::Float64)
+        pop::Float64,
+        conc::Float64,
+        as::Float64,
+        ϕs::Float64,
+        mic::Microbe,
+        Tmax::Float64)
     # Preallocate memory
     rate = zeros(1, ps.O)
     # Now substitute preallocated memory in
@@ -431,12 +431,12 @@ end
 
 # function to test for competition between two populations
 function doub_pop(ps::TOParameters,
-                  pop::Float64,
-                  conc::Float64,
-                  as::Float64,
-                  ϕs::Float64,
-                  mics::Array{Microbe, 1},
-                  Tmax::Float64)
+        pop::Float64,
+        conc::Float64,
+        as::Float64,
+        ϕs::Float64,
+        mics::Array{Microbe, 1},
+        Tmax::Float64)
     # Check correct number of microbes has been provided
     if length(mics) != 2
         error("must provide two microbes")


### PR DESCRIPTION
This makes the simulation code compatible with Julia 1.10 first by converting the simulation output from Adjoint type to Matrix type, which still has a `getindex!()` method (unlike Adjoint)